### PR TITLE
kafka: change logging wrapper for better log message handling;

### DIFF
--- a/pkg/kafka/logging/logger.go
+++ b/pkg/kafka/logging/logger.go
@@ -1,6 +1,8 @@
 package logging
 
 import (
+	"fmt"
+
 	"github.com/justtrackio/gosoline/pkg/log"
 )
 
@@ -17,9 +19,17 @@ func NewKafkaLogger(logger log.Logger) *KafkaLogger {
 }
 
 func (l *KafkaLogger) DebugLogger() LoggerWrapper {
-	return l.Debug
+	return func(template string, values ...interface{}) {
+		l.WithFields(log.Fields{
+			"details": fmt.Sprintf(template, values...),
+		}).Debug("segmentio kafka-go debug")
+	}
 }
 
 func (l *KafkaLogger) ErrorLogger() LoggerWrapper {
-	return l.Error
+	return func(template string, values ...interface{}) {
+		l.WithFields(log.Fields{
+			"error": fmt.Sprintf(template, values...),
+		}).Error("segmentio kafka-go error")
+	}
 }

--- a/pkg/kafka/logging/logger_test.go
+++ b/pkg/kafka/logging/logger_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/justtrackio/gosoline/pkg/kafka/logging"
+	"github.com/justtrackio/gosoline/pkg/log"
 	logMocks "github.com/justtrackio/gosoline/pkg/log/mocks"
 )
 
@@ -16,9 +17,11 @@ func TestKafkaLogger(t *testing.T) {
 	defer loggerWithChannel.AssertExpectations(t)
 
 	logger.On("WithChannel", "stream.kafka").Return(loggerWithChannel).Once()
+	loggerWithChannel.On("WithFields", log.Fields{"details": "debug message"}).Return(loggerWithChannel).Once()
+	loggerWithChannel.On("WithFields", log.Fields{"error": "error message"}).Return(loggerWithChannel).Once()
 
-	loggerWithChannel.On("Debug", "debug message").Once()
-	loggerWithChannel.On("Error", "error message").Once()
+	loggerWithChannel.On("Debug", "segmentio kafka-go debug").Once()
+	loggerWithChannel.On("Error", "segmentio kafka-go error").Once()
 
 	kLogger := logging.NewKafkaLogger(logger)
 	kLogger.DebugLogger().Printf("debug message")


### PR DESCRIPTION
Changed the logging structure since it already has the same stuff in the fields. We want better filtering on ES.