### PR TITLE
kafka: add configuration for disabling debug logs;

### DIFF
--- a/pkg/kafka/consumer/reader.go
+++ b/pkg/kafka/consumer/reader.go
@@ -71,7 +71,13 @@ func NewReader(
 
 		StartOffset: kafka.LastOffset,
 
-		Logger:      logging.NewKafkaLogger(logger).DebugLogger(),
+		Logger: func() logging.LoggerWrapper {
+			// Sets logger if debug logs are enabled.
+			if conf.DebugLogs {
+				return logging.NewKafkaLogger(logger).DebugLogger()
+			}
+			return nil
+		}(),
 		ErrorLogger: logging.NewKafkaLogger(logger).ErrorLogger(),
 	}
 

--- a/pkg/kafka/consumer/reader_test.go
+++ b/pkg/kafka/consumer/reader_test.go
@@ -40,6 +40,8 @@ func TestSaneDefaults(t *testing.T) {
 	assert.Equal(t, reader.Config().GroupID, readerConf.FQGroupID)
 
 	assert.Equal(t, reader.Config().StartOffset, kafka.LastOffset)
+	assert.Nil(t, reader.Config().Logger)
+	assert.NotNil(t, reader.Config().ErrorLogger)
 }
 
 func TestFallsbackToSaneDefaults(t *testing.T) {

--- a/pkg/kafka/consumer/settings.go
+++ b/pkg/kafka/consumer/settings.go
@@ -21,6 +21,8 @@ type Settings struct {
 	FQGroupID    string
 	BatchSize    int           `cfg:"batch_size" default:"1"`
 	BatchTimeout time.Duration `cfg:"idle_timeout" default:"10ms"`
+	// Enables debug logs for segmentio/kafka module.
+	DebugLogs bool `cfg:"debug_logs" default:"false"`
 }
 
 func (s *Settings) Connection() *connection.Settings {

--- a/pkg/kafka/producer/producer.go
+++ b/pkg/kafka/producer/producer.go
@@ -31,7 +31,7 @@ func NewProducer(_ context.Context, conf cfg.Config, logger log.Logger, name str
 	}
 
 	// Writer.
-	writer, err := NewWriter(logger, dialer, settings.Connection().Bootstrap, getOptions(settings)...)
+	writer, err := NewWriter(logger, dialer, settings, getOptions(settings)...)
 	if err != nil {
 		return nil, fmt.Errorf("kafka: failed to get writer: %w", err)
 	}

--- a/pkg/kafka/producer/settings.go
+++ b/pkg/kafka/producer/settings.go
@@ -20,7 +20,8 @@ type Settings struct {
 	Balancer     string        `cfg:"balancer" default:"default"`
 	Retries      int           `cfg:"retries" default:"5"`
 	WriteTimeout time.Duration `cfg:"write_timeout" default:"30s"`
-
+	// Enables debug logs for segmentio/kafka module.
+	DebugLogs  bool `cfg:"debug_logs" default:"false"`
 	connection *connection.Settings
 }
 

--- a/pkg/kafka/producer/writer_test.go
+++ b/pkg/kafka/producer/writer_test.go
@@ -31,7 +31,7 @@ var (
 
 func TestTransport(t *testing.T) {
 	writer, err := producer.NewWriter(
-		logMocks.NewLoggerMockedAll(), writerDialer, writerConf.Connection().Bootstrap,
+		logMocks.NewLoggerMockedAll(), writerDialer, writerConf,
 		producer.WithBalancer(&kafka.Hash{}),
 	)
 	assert.Nil(t, err)
@@ -52,7 +52,7 @@ func TestTransport(t *testing.T) {
 }
 
 func TestSaneDefaults(t *testing.T) {
-	writer, err := producer.NewWriter(logMocks.NewLoggerMockedAll(), writerDialer, writerConf.Connection().Bootstrap)
+	writer, err := producer.NewWriter(logMocks.NewLoggerMockedAll(), writerDialer, writerConf)
 	assert.Nil(t, err)
 
 	// Endpoint
@@ -68,11 +68,13 @@ func TestSaneDefaults(t *testing.T) {
 
 	// Performance.
 	assert.Equal(t, writer.Compression, kafka.Snappy)
+	assert.Nil(t, writer.Logger)
+	assert.NotNil(t, writer.ErrorLogger)
 }
 
 func TestSaneDefaultsFallback(t *testing.T) {
 	writer, err := producer.NewWriter(
-		logMocks.NewLoggerMockedAll(), writerDialer, writerConf.Connection().Bootstrap,
+		logMocks.NewLoggerMockedAll(), writerDialer, writerConf,
 		producer.WithBatch(0, time.Microsecond),
 	)
 	assert.Nil(t, err)
@@ -88,7 +90,7 @@ func TestWithBatch(t *testing.T) {
 	)
 
 	writer, err := producer.NewWriter(
-		logMocks.NewLoggerMockedAll(), writerDialer, writerConf.Connection().Bootstrap,
+		logMocks.NewLoggerMockedAll(), writerDialer, writerConf,
 		producer.WithBatch(batchSize, batchInterval),
 	)
 	assert.Nil(t, err)
@@ -100,7 +102,7 @@ func TestWithBatch(t *testing.T) {
 
 func TestWithAsyncWrites(t *testing.T) {
 	writer, err := producer.NewWriter(
-		logMocks.NewLoggerMockedAll(), writerDialer, writerConf.Connection().Bootstrap,
+		logMocks.NewLoggerMockedAll(), writerDialer, writerConf,
 		producer.WithAsyncWrites(),
 	)
 
@@ -113,7 +115,7 @@ func TestWithWriteTimeout(t *testing.T) {
 	writer, err := producer.NewWriter(
 		logMocks.NewLoggerMockedAll(),
 		writerDialer,
-		writerConf.Connection().Bootstrap,
+		writerConf,
 		producer.WithWriteTimeout(timeout),
 	)
 	assert.Nil(t, err)


### PR DESCRIPTION
Introduced a new field for kafka producer and writer config called `debug_logs`. Default value is `false`, which sets logger object of segmentio writer/producer to nil. The module seems to be handling that case. We have too much kafka logs in Loki, it is good to have an option to disable it.