### PR TITLE
log: log level per channel

### DIFF
--- a/docs/log/custom_handler.go
+++ b/docs/log/custom_handler.go
@@ -9,7 +9,7 @@ import (
 )
 
 type MyCustomHandlerSettings struct {
-	Channel string `cfg:"channel"`
+	Channel log.Channel `cfg:"channel"`
 }
 
 func MyCustomHandlerFactory(config cfg.Config, name string) (log.Handler, error) {
@@ -22,11 +22,11 @@ func MyCustomHandlerFactory(config cfg.Config, name string) (log.Handler, error)
 }
 
 type MyCustomHandler struct {
-	channel string
+	channel log.Channel
 }
 
-func (h *MyCustomHandler) Channels() []string {
-	return []string{h.channel}
+func (h *MyCustomHandler) Channels() []log.Channel {
+	return []log.Channel{h.channel}
 }
 
 func (h *MyCustomHandler) Level() int {

--- a/docs/log/readme.md
+++ b/docs/log/readme.md
@@ -47,18 +47,21 @@ log:
     handlers:
         main:
             type: iowriter
-            channels: []
+            channels:
+              - name: metrics
+                level: error
+                disabled: false
             formatter: console
             level: info
             timestamp_format: 15:04:05.000
             writer: stdout
 ```
 
-| setting             | description                                                    | default                                                                            |
-|---------------------|----------------------------------------------------------------|------------------------------------------------------------------------------------|
-| log.level           | default level for all handlers without an explicit level value | info                                                                               |
-| log.handlers        | a map of handlers that will be called for every log message   | every logger gets a 'main' handler by default if there is no other handler defined |
-| log.handlers.X.type | defines the type of the handler                                | -                                                                                  |
+| setting             | description                                                        | default                                                                            |
+|---------------------|--------------------------------------------------------------------|------------------------------------------------------------------------------------|
+| log.level           | default level for all logs without an explicit channel level value | info                                                                               |
+| log.handlers        | a map of handlers that will be called for every log message        | every logger gets a 'main' handler by default if there is no other handler defined |
+| log.handlers.X.type | defines the type of the handler                                    | -                                                                                  |
 
 ## Handlers
 Handlers have to implement the following interface:
@@ -66,13 +69,13 @@ Handlers have to implement the following interface:
 [embedmd]:# (../../pkg/log/handler.go /type Handler interface {/ /\n}/)
 ```go
 type Handler interface {
-	Channels() []string
+	Channels() []Channel
 	Level() int
 	Log(timestamp time.Time, level int, msg string, args []interface{}, err error, data Data) error
 }
 ```
 
-`Channels() []string` and `Level() int` are called on every log action to check if the handler should be applied. `Log` does the actual logging afterwards.
+`Channels() []Channel` and `Level() int` are called on every log action to check if the handler should be applied. `Log` does the actual logging afterwards.
 
 ### Implementing a handler and make it available via config
 
@@ -89,7 +92,7 @@ import (
 )
 
 type MyCustomHandlerSettings struct {
-	Channel string `cfg:"channel"`
+	Channel log.Channel `cfg:"channel"`
 }
 
 func MyCustomHandlerFactory(config cfg.Config, name string) (log.Handler, error) {
@@ -102,11 +105,11 @@ func MyCustomHandlerFactory(config cfg.Config, name string) (log.Handler, error)
 }
 
 type MyCustomHandler struct {
-	channel string
+	channel log.Channel
 }
 
-func (h *MyCustomHandler) Channels() []string {
-	return []string{h.channel}
+func (h *MyCustomHandler) Channels() []log.Channel {
+	return []log.Channel{h.channel}
 }
 
 func (h *MyCustomHandler) Level() int {
@@ -129,7 +132,9 @@ log:
   handlers:
     main:
       type: my-custom-handler
-      channel: important
+      channels:
+        - name: important
+          level: warn
 ```
 
 ### Build-in handlers
@@ -141,10 +146,21 @@ Multitool, which is able to write logs to everything which implements the `io.Wr
 | Setting          | Description                                                        | Default      |
 |------------------|--------------------------------------------------------------------|--------------|
 | level            | Levels of this and higher priority will get logged                 | info         |
-| channels         | Messages logged into these channels will be handled                | []           |
+| channels         | Settings for per channel output configurations                     | []           |
 | formatter        | Which format should be used by this handler                        | console      |
 | timestamp_format | A golang time format string to control the format of the timestamp | 15:04:05.000 |
 | writer           | Which io.writer implementation to use                              | stdout       |
+
+##### Channel settings
+Handling outputs per channel is possible with following structure:
+
+| Setting          | Description                                        | Default |
+|------------------|----------------------------------------------------|---------|
+| level            | Levels of this and higher priority will get logged | info    |
+| name             | Name of the channel that this ruleset applies to   |         |
+| disabled         | Toggles logging for specified channel              | false   |
+
+
 
 ##### log to stdout
 ```yaml
@@ -153,7 +169,6 @@ log:
     main:
       type: iowriter
       level: info
-      channels: []
       formatter: console
       timestamp_format: 15:04:05.000
       writer: stdout
@@ -165,11 +180,26 @@ log:
     main:
       type: iowriter
       level: info
-      channels: *
       formatter: console
       timestamp_format: 15:04:05.000
       writer: file
       path: logs.log
+```
+##### skip metrics channel, log above warning level for app channel
+```yaml
+log:
+  handlers:
+    main:
+      type: iowriter
+      level: info
+      formatter: console
+      timestamp_format: 15:04:05.000
+      writer: stdout
+      channels:
+        - name: metrics
+          disabled: true
+        - name: app
+          level: warn
 ```
 
 #### metric
@@ -184,7 +214,7 @@ No configuration needed. Publishes every logged error to sentry.
 ```go
 func Usage() {
 	ctx := context.Background()
-	handler := log.NewHandlerIoWriter(log.LevelDebug, []string{}, log.FormatterConsole, "15:04:05.000", os.Stdout)
+	handler := log.NewHandlerIoWriter(log.LevelDebug, []log.Channel{}, log.FormatterConsole, "15:04:05.000", os.Stdout)
 	logger := log.NewLoggerWithInterfaces(clock.NewRealClock(), []log.Handler{handler})
 
 	if err := logger.Option(log.WithContextFieldsResolver(log.ContextLoggerFieldsResolver)); err != nil {

--- a/docs/log/usage.go
+++ b/docs/log/usage.go
@@ -1,4 +1,4 @@
-//nolint
+// nolint
 package main
 
 import (
@@ -12,7 +12,7 @@ import (
 
 func Usage() {
 	ctx := context.Background()
-	handler := log.NewHandlerIoWriter(log.LevelDebug, []string{}, log.FormatterConsole, "15:04:05.000", os.Stdout)
+	handler := log.NewHandlerIoWriter(log.LevelDebug, []log.Channel{}, log.FormatterConsole, "15:04:05.000", os.Stdout)
 	logger := log.NewLoggerWithInterfaces(clock.NewRealClock(), []log.Handler{handler})
 
 	if err := logger.Option(log.WithContextFieldsResolver(log.ContextLoggerFieldsResolver)); err != nil {

--- a/pkg/apiserver/crud/crud_test.go
+++ b/pkg/apiserver/crud/crud_test.go
@@ -14,7 +14,7 @@ import (
 	logMocks "github.com/justtrackio/gosoline/pkg/log/mocks"
 	"github.com/justtrackio/gosoline/pkg/mdl"
 	"github.com/justtrackio/gosoline/pkg/validation"
-	"github.com/stretchr/testify/assert"
+
 	"github.com/stretchr/testify/mock"
 )
 
@@ -127,11 +127,11 @@ func TestCreateHandler_Handle(t *testing.T) {
 	logger := logMocks.NewLoggerMockedAll()
 	transformer := NewTransformer()
 
-	transformer.Repo.On("Create", mock.AnythingOfType("context.backgroundCtx"), model).Run(func(args mock.Arguments) {
+	transformer.Repo.On("Create", mock.AnythingOfType("*context.emptyCtx"), model).Run(func(args mock.Arguments) {
 		model := args.Get(1).(*Model)
 		model.Id = mdl.Box(uint(1))
 	}).Return(nil)
-	transformer.Repo.On("Read", mock.AnythingOfType("context.backgroundCtx"), mdl.Box(uint(1)), &Model{}).Run(func(args mock.Arguments) {
+	transformer.Repo.On("Read", mock.AnythingOfType("*context.emptyCtx"), mdl.Box(uint(1)), &Model{}).Run(func(args mock.Arguments) {
 		model := args.Get(2).(*Model)
 		model.Id = mdl.Box(uint(1))
 		model.Name = mdl.Box("foobar")
@@ -158,7 +158,7 @@ func TestCreateHandler_Handle_ValidationError(t *testing.T) {
 	logger := logMocks.NewLoggerMockedAll()
 	transformer := NewTransformer()
 
-	transformer.Repo.On("Create", mock.AnythingOfType("context.backgroundCtx"), model).Return(&validation.Error{
+	transformer.Repo.On("Create", mock.AnythingOfType("*context.emptyCtx"), model).Return(&validation.Error{
 		Errors: []error{fmt.Errorf("invalid foobar")},
 	})
 
@@ -178,7 +178,7 @@ func TestReadHandler_Handle(t *testing.T) {
 
 	logger := logMocks.NewLoggerMockedAll()
 	transformer := NewTransformer()
-	transformer.Repo.On("Read", mock.AnythingOfType("context.backgroundCtx"), mdl.Box(uint(1)), model).Run(func(args mock.Arguments) {
+	transformer.Repo.On("Read", mock.AnythingOfType("*context.emptyCtx"), mdl.Box(uint(1)), model).Run(func(args mock.Arguments) {
 		model := args.Get(2).(*Model)
 		model.Id = mdl.Box(uint(1))
 		model.Name = mdl.Box("foobar")
@@ -212,8 +212,8 @@ func TestUpdateHandler_Handle(t *testing.T) {
 	logger := logMocks.NewLoggerMockedAll()
 	transformer := NewTransformer()
 
-	transformer.Repo.On("Update", mock.AnythingOfType("context.backgroundCtx"), updateModel).Return(nil)
-	transformer.Repo.On("Read", mock.AnythingOfType("context.backgroundCtx"), mdl.Box(uint(1)), readModel).Run(func(args mock.Arguments) {
+	transformer.Repo.On("Update", mock.AnythingOfType("*context.emptyCtx"), updateModel).Return(nil)
+	transformer.Repo.On("Read", mock.AnythingOfType("*context.emptyCtx"), mdl.Box(uint(1)), readModel).Run(func(args mock.Arguments) {
 		model := args.Get(2).(*Model)
 		model.Id = mdl.Box(uint(1))
 		model.Name = mdl.Box("updated")
@@ -248,10 +248,10 @@ func TestUpdateHandler_Handle_ValidationError(t *testing.T) {
 	logger := logMocks.NewLoggerMockedAll()
 	transformer := NewTransformer()
 
-	transformer.Repo.On("Update", mock.AnythingOfType("context.backgroundCtx"), updateModel).Return(&validation.Error{
+	transformer.Repo.On("Update", mock.AnythingOfType("*context.emptyCtx"), updateModel).Return(&validation.Error{
 		Errors: []error{fmt.Errorf("invalid foobar")},
 	})
-	transformer.Repo.On("Read", mock.AnythingOfType("context.backgroundCtx"), mdl.Box(uint(1)), readModel).Run(func(args mock.Arguments) {
+	transformer.Repo.On("Read", mock.AnythingOfType("*context.emptyCtx"), mdl.Box(uint(1)), readModel).Run(func(args mock.Arguments) {
 		model := args.Get(2).(*Model)
 		model.Id = mdl.Box(uint(1))
 		model.Name = mdl.Box("updated")
@@ -285,14 +285,14 @@ func TestDeleteHandler_Handle(t *testing.T) {
 
 	logger := logMocks.NewLoggerMockedAll()
 	transformer := NewTransformer()
-	transformer.Repo.On("Read", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("*uint"), model).Run(func(args mock.Arguments) {
+	transformer.Repo.On("Read", mock.AnythingOfType("*context.emptyCtx"), mock.AnythingOfType("*uint"), model).Run(func(args mock.Arguments) {
 		model := args.Get(2).(*Model)
 		model.Id = id1
 		model.Name = mdl.Box("foobar")
 		model.UpdatedAt = &time.Time{}
 		model.CreatedAt = &time.Time{}
 	}).Return(nil)
-	transformer.Repo.On("Delete", mock.AnythingOfType("context.backgroundCtx"), deleteModel).Return(nil)
+	transformer.Repo.On("Delete", mock.AnythingOfType("*context.emptyCtx"), deleteModel).Return(nil)
 
 	handler := crud.NewDeleteHandler(logger, transformer)
 
@@ -319,14 +319,14 @@ func TestDeleteHandler_Handle_ValidationError(t *testing.T) {
 
 	logger := logMocks.NewLoggerMockedAll()
 	transformer := NewTransformer()
-	transformer.Repo.On("Read", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("*uint"), model).Run(func(args mock.Arguments) {
+	transformer.Repo.On("Read", mock.AnythingOfType("*context.emptyCtx"), mock.AnythingOfType("*uint"), model).Run(func(args mock.Arguments) {
 		model := args.Get(2).(*Model)
 		model.Id = id1
 		model.Name = mdl.Box("foobar")
 		model.UpdatedAt = &time.Time{}
 		model.CreatedAt = &time.Time{}
 	}).Return(nil)
-	transformer.Repo.On("Delete", mock.AnythingOfType("context.backgroundCtx"), deleteModel).Return(&validation.Error{
+	transformer.Repo.On("Delete", mock.AnythingOfType("*context.emptyCtx"), deleteModel).Return(&validation.Error{
 		Errors: []error{fmt.Errorf("invalid foobar")},
 	})
 
@@ -360,7 +360,7 @@ func TestListHandler_Handle(t *testing.T) {
 			"name": db_repo.NewFieldMapping("name"),
 		},
 	})
-	transformer.Repo.On("Count", mock.AnythingOfType("context.backgroundCtx"), qb, &Model{}).Return(1, nil)
+	transformer.Repo.On("Count", mock.AnythingOfType("*context.emptyCtx"), qb, &Model{}).Return(1, nil)
 
 	body := `{"filter":{"matches":[{"values":["foobar"],"dimension":"name","operator":"="}],"bool":"and"},"order":[{"field":"name","direction":"ASC"}],"page":{"offset":0,"limit":2}}`
 	response := apiserver.HttpTest("PUT", "/:id", "/1", body, handler)

--- a/pkg/application/error.go
+++ b/pkg/application/error.go
@@ -15,7 +15,7 @@ func WithDefaultErrorHandler(handler ErrorHandler) {
 }
 
 var defaultErrorHandler = func(msg string, args ...interface{}) {
-	writerHandler := log.NewHandlerIoWriter(log.LevelInfo, []string{}, log.FormatterJson, "2006-01-02T15:04:05.999Z07:00", os.Stdout)
+	writerHandler := log.NewHandlerIoWriter(log.LevelInfo, []log.Channel{}, log.FormatterJson, "2006-01-02T15:04:05.999Z07:00", os.Stdout)
 	metricHandler := metric.NewLoggerHandler()
 
 	logger := log.NewLoggerWithInterfaces(clock.Provider, []log.Handler{

--- a/pkg/cli/logger.go
+++ b/pkg/cli/logger.go
@@ -16,7 +16,7 @@ func newCliLogger() (log.Logger, error) {
 		return nil, fmt.Errorf("can not create io file writer for logger: %w", err)
 	}
 
-	handler := log.NewHandlerIoWriter(log.LevelInfo, []string{}, log.FormatterConsole, "", writer)
+	handler := log.NewHandlerIoWriter(log.LevelInfo, []log.Channel{}, log.FormatterConsole, "", writer)
 	logger := log.NewLoggerWithInterfaces(clock.Provider, []log.Handler{handler})
 
 	return logger, nil

--- a/pkg/grpcserver/health_test.go
+++ b/pkg/grpcserver/health_test.go
@@ -58,7 +58,7 @@ func Test_healthServer_Check(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := grpcserver.NewHealthServer(logger, cancelFunc)
+			s := grpcserver.NewHealthServer(logger, cancelFunc, false)
 
 			if tt.callback != nil {
 				s.AddCallback(tt.callback.ServiceName, tt.callback.HealthCheckCallback)

--- a/pkg/kafka/consumer/consumer_offset_manager_test.go
+++ b/pkg/kafka/consumer/consumer_offset_manager_test.go
@@ -271,7 +271,7 @@ func TestOffsetManager_FetchMessageErrors(t *testing.T) {
 		readerErr = errors.New("reader: failed")
 	)
 
-	reader.On("FetchMessage", mock.AnythingOfType("context.backgroundCtx")).Return(
+	reader.On("FetchMessage", mock.AnythingOfType("*context.emptyCtx")).Return(
 		func(ctx context.Context) kafka.Message {
 			time.Sleep(time.Millisecond)
 			return kafka.Message{}
@@ -299,7 +299,7 @@ func TestOffsetManager_FlushErrors(t *testing.T) {
 		readerErr = errors.New("reader: failed")
 	)
 
-	reader.On("FetchMessage", mock.AnythingOfType("context.backgroundCtx")).Return(
+	reader.On("FetchMessage", mock.AnythingOfType("*context.emptyCtx")).Return(
 		func(ctx context.Context) kafka.Message {
 			time.Sleep(time.Millisecond)
 			return kafka.Message{}

--- a/pkg/kafka/logging/logger_test.go
+++ b/pkg/kafka/logging/logger_test.go
@@ -20,10 +20,10 @@ func TestKafkaLogger(t *testing.T) {
 	loggerWithChannel.On("WithFields", log.Fields{"details": "debug message"}).Return(loggerWithChannel).Once()
 	loggerWithChannel.On("WithFields", log.Fields{"error": "error message"}).Return(loggerWithChannel).Once()
 
-	loggerWithChannel.On("Debug", "segmentio kafka-go debug").Once()
+	loggerWithChannel.On("Debug", "segmentio kafka-go debug", []interface{}(nil)).Once()
 	loggerWithChannel.On("Error", "segmentio kafka-go error").Once()
 
-	kLogger := logging.NewKafkaLogger(logger)
+	kLogger := logging.NewKafkaLogger(logger, logging.WithDebugLogging(true))
 	kLogger.DebugLogger().Printf("debug message")
 	kLogger.ErrorLogger().Printf("error message")
 }

--- a/pkg/kvstore/ddb_test.go
+++ b/pkg/kvstore/ddb_test.go
@@ -19,7 +19,7 @@ func TestDdbKvStore_Contains(t *testing.T) {
 	builder.On("WithHash", "foo").Return(builder).Once()
 
 	repo.On("GetItemBuilder").Return(builder)
-	repo.On("GetItem", mock.AnythingOfType("context.backgroundCtx"), builder, mock.AnythingOfType("*kvstore.DdbItem")).Return(&ddb.GetItemResult{
+	repo.On("GetItem", mock.AnythingOfType("*context.emptyCtx"), builder, mock.AnythingOfType("*kvstore.DdbItem")).Return(&ddb.GetItemResult{
 		IsFound: true,
 	}, nil).Once()
 
@@ -28,7 +28,7 @@ func TestDdbKvStore_Contains(t *testing.T) {
 	assert.True(t, exists)
 
 	builder.On("WithHash", "fuu").Return(builder).Once()
-	repo.On("GetItem", mock.AnythingOfType("context.backgroundCtx"), builder, mock.AnythingOfType("*kvstore.DdbItem")).Return(&ddb.GetItemResult{
+	repo.On("GetItem", mock.AnythingOfType("*context.emptyCtx"), builder, mock.AnythingOfType("*kvstore.DdbItem")).Return(&ddb.GetItemResult{
 		IsFound: false,
 	}, nil).Once()
 
@@ -52,7 +52,7 @@ func TestDdbKvStore_Get(t *testing.T) {
 	}
 
 	repo.On("GetItemBuilder").Return(builder)
-	repo.On("GetItem", mock.AnythingOfType("context.backgroundCtx"), builder, ddbItem).Run(func(args mock.Arguments) {
+	repo.On("GetItem", mock.AnythingOfType("*context.emptyCtx"), builder, ddbItem).Run(func(args mock.Arguments) {
 		ddbItem := args[2].(*kvstore.DdbItem)
 		ddbItem.Key = "foo"
 		ddbItem.Value = `{"id":"foo","body":"bar"}`
@@ -84,7 +84,7 @@ func TestDdbKvStore_GetBatch(t *testing.T) {
 	items := make([]kvstore.DdbItem, 0)
 
 	repo.On("BatchGetItemsBuilder").Return(builder)
-	repo.On("BatchGetItems", mock.AnythingOfType("context.backgroundCtx"), builder, &items).Run(func(args mock.Arguments) {
+	repo.On("BatchGetItems", mock.AnythingOfType("*context.emptyCtx"), builder, &items).Run(func(args mock.Arguments) {
 		item := kvstore.DdbItem{
 			Key:   "foo",
 			Value: `{"id":"foo","body":"bar"}`,
@@ -120,7 +120,7 @@ func TestDdbKvStore_GetBatch_ReturnedKeysInDifferentOrder(t *testing.T) {
 	repo.On("BatchGetItemsBuilder").Return(builder)
 
 	// the order of the entries is not always the same as the order of the keys
-	repo.On("BatchGetItems", mock.AnythingOfType("context.backgroundCtx"), builder, &items).Run(func(args mock.Arguments) {
+	repo.On("BatchGetItems", mock.AnythingOfType("*context.emptyCtx"), builder, &items).Run(func(args mock.Arguments) {
 		items := args[2].(*[]kvstore.DdbItem)
 		*items = append(*items, kvstore.DdbItem{
 			Key:   "fuu",
@@ -161,7 +161,7 @@ func TestDdbKvStore_GetBatch_WithDuplicateKeys(t *testing.T) {
 	items := make([]kvstore.DdbItem, 0)
 
 	repo.On("BatchGetItemsBuilder").Return(builder)
-	repo.On("BatchGetItems", mock.AnythingOfType("context.backgroundCtx"), builder, &items).Run(func(args mock.Arguments) {
+	repo.On("BatchGetItems", mock.AnythingOfType("*context.emptyCtx"), builder, &items).Run(func(args mock.Arguments) {
 		item := kvstore.DdbItem{
 			Key:   "foo",
 			Value: `{"id":"foo","body":"bar"}`,
@@ -192,7 +192,7 @@ func TestDdbKvStore_Put(t *testing.T) {
 		Key:   "foo",
 		Value: `{"id":"foo","body":"bar"}`,
 	}
-	repo.On("PutItem", mock.AnythingOfType("context.backgroundCtx"), nil, ddbItem).Return(nil, nil)
+	repo.On("PutItem", mock.AnythingOfType("*context.emptyCtx"), nil, ddbItem).Return(nil, nil)
 
 	item := Item{
 		Id:   "foo",
@@ -218,7 +218,7 @@ func TestDdbKvStore_PutBatch(t *testing.T) {
 			Value: `{"id":"fuu","body":"baz"}`,
 		},
 	}
-	repo.On("BatchPutItems", mock.AnythingOfType("context.backgroundCtx"), ddbItems).Return(nil, nil)
+	repo.On("BatchPutItems", mock.AnythingOfType("*context.emptyCtx"), ddbItems).Return(nil, nil)
 
 	items := map[string]Item{
 		"fuu": {
@@ -243,7 +243,7 @@ func TestDdbKvStore_Delete(t *testing.T) {
 	ddbItem := &kvstore.DdbDeleteItem{
 		Key: "foo",
 	}
-	repo.On("DeleteItem", mock.AnythingOfType("context.backgroundCtx"), nil, ddbItem).Return(nil, nil)
+	repo.On("DeleteItem", mock.AnythingOfType("*context.emptyCtx"), nil, ddbItem).Return(nil, nil)
 
 	err := store.Delete(context.Background(), "foo")
 
@@ -262,7 +262,7 @@ func TestDdbKvStore_DeleteBatch(t *testing.T) {
 			Key: "fuu",
 		},
 	}
-	repo.On("BatchDeleteItems", mock.AnythingOfType("context.backgroundCtx"), ddbItems).Return(nil, nil)
+	repo.On("BatchDeleteItems", mock.AnythingOfType("*context.emptyCtx"), ddbItems).Return(nil, nil)
 
 	items := []string{"foo", "fuu"}
 

--- a/pkg/kvstore/redis_test.go
+++ b/pkg/kvstore/redis_test.go
@@ -22,8 +22,8 @@ type Item struct {
 func TestRedisKvStore_Contains(t *testing.T) {
 	store, client := buildTestableRedisStore[Item]()
 
-	client.On("Exists", mock.AnythingOfType("context.backgroundCtx"), "applike-gosoline-kvstore-kvstore-test-foo").Return(int64(0), nil)
-	client.On("Exists", mock.AnythingOfType("context.backgroundCtx"), "applike-gosoline-kvstore-kvstore-test-bar").Return(int64(1), nil)
+	client.On("Exists", mock.AnythingOfType("*context.emptyCtx"), "applike-gosoline-kvstore-kvstore-test-foo").Return(int64(0), nil)
+	client.On("Exists", mock.AnythingOfType("*context.emptyCtx"), "applike-gosoline-kvstore-kvstore-test-bar").Return(int64(1), nil)
 
 	exists, err := store.Contains(context.Background(), "foo")
 	assert.NoError(t, err)
@@ -38,7 +38,7 @@ func TestRedisKvStore_Contains(t *testing.T) {
 
 func TestRedisKvStore_Get(t *testing.T) {
 	store, client := buildTestableRedisStore[Item]()
-	client.On("Get", mock.AnythingOfType("context.backgroundCtx"), "applike-gosoline-kvstore-kvstore-test-foo").Return(`{"id":"foo","body":"bar"}`, nil)
+	client.On("Get", mock.AnythingOfType("*context.emptyCtx"), "applike-gosoline-kvstore-kvstore-test-foo").Return(`{"id":"foo","body":"bar"}`, nil)
 
 	item := &Item{}
 	found, err := store.Get(context.Background(), "foo", item)
@@ -54,7 +54,7 @@ func TestRedisKvStore_Get(t *testing.T) {
 func TestRedisKvStore_GetBatch(t *testing.T) {
 	store, client := buildTestableRedisStore[Item]()
 
-	args := []interface{}{mock.AnythingOfType("context.backgroundCtx"), "applike-gosoline-kvstore-kvstore-test-foo", "applike-gosoline-kvstore-kvstore-test-fuu"}
+	args := []interface{}{mock.AnythingOfType("*context.emptyCtx"), "applike-gosoline-kvstore-kvstore-test-foo", "applike-gosoline-kvstore-kvstore-test-fuu"}
 	returns := []interface{}{`{"id":"foo","body":"bar"}`, nil}
 
 	client.On("MGet", args...).Return(returns, nil)
@@ -77,7 +77,7 @@ func TestRedisKvStore_GetBatch(t *testing.T) {
 
 func TestRedisKvStore_Put(t *testing.T) {
 	store, client := buildTestableRedisStore[Item]()
-	client.On("Set", mock.AnythingOfType("context.backgroundCtx"), "applike-gosoline-kvstore-kvstore-test-foo", []byte(`{"id":"foo","body":"bar"}`), time.Duration(0)).Return(nil)
+	client.On("Set", mock.AnythingOfType("*context.emptyCtx"), "applike-gosoline-kvstore-kvstore-test-foo", []byte(`{"id":"foo","body":"bar"}`), time.Duration(0)).Return(nil)
 
 	item := Item{
 		Id:   "foo",
@@ -94,7 +94,7 @@ func TestRedisKvStore_PutBatch(t *testing.T) {
 	store, client := buildTestableRedisStoreWithTTL[Item]()
 
 	pipe := &redisMocks.Pipeliner{}
-	pipe.On("MSet", mock.AnythingOfType("context.backgroundCtx"), mock.MatchedBy(func(input []interface{}) bool {
+	pipe.On("MSet", mock.AnythingOfType("*context.emptyCtx"), mock.MatchedBy(func(input []interface{}) bool {
 		possibleInput1 := `[applike-gosoline-kvstore-kvstore-test-foo {"id":"foo","body":"bar"} applike-gosoline-kvstore-kvstore-test-fuu {"id":"fuu","body":"baz"}]`
 		possibleInput2 := `[applike-gosoline-kvstore-kvstore-test-fuu {"id":"fuu","body":"baz"} applike-gosoline-kvstore-kvstore-test-foo {"id":"foo","body":"bar"}]`
 
@@ -103,9 +103,9 @@ func TestRedisKvStore_PutBatch(t *testing.T) {
 	})).Return(nil)
 	client.On("Pipeline").Return(pipe)
 	pipe.On("TxPipeline").Return(pipe)
-	pipe.On("Expire", mock.AnythingOfType("context.backgroundCtx"), "applike-gosoline-kvstore-kvstore-test-foo", mock.AnythingOfType("time.Duration")).Return(nil)
-	pipe.On("Expire", mock.AnythingOfType("context.backgroundCtx"), "applike-gosoline-kvstore-kvstore-test-fuu", mock.AnythingOfType("time.Duration")).Return(nil)
-	pipe.On("Exec", mock.AnythingOfType("context.backgroundCtx")).Return(nil, nil)
+	pipe.On("Expire", mock.AnythingOfType("*context.emptyCtx"), "applike-gosoline-kvstore-kvstore-test-foo", mock.AnythingOfType("time.Duration")).Return(nil)
+	pipe.On("Expire", mock.AnythingOfType("*context.emptyCtx"), "applike-gosoline-kvstore-kvstore-test-fuu", mock.AnythingOfType("time.Duration")).Return(nil)
+	pipe.On("Exec", mock.AnythingOfType("*context.emptyCtx")).Return(nil, nil)
 
 	items := map[string]Item{
 		"foo": {
@@ -128,7 +128,7 @@ func TestRedisKvStore_PutBatchSkipExpire(t *testing.T) {
 	store, client := buildTestableRedisStore[Item]()
 
 	pipe := &redisMocks.Pipeliner{}
-	pipe.On("MSet", mock.AnythingOfType("context.backgroundCtx"), mock.MatchedBy(func(input []interface{}) bool {
+	pipe.On("MSet", mock.AnythingOfType("*context.emptyCtx"), mock.MatchedBy(func(input []interface{}) bool {
 		possibleInput1 := `[applike-gosoline-kvstore-kvstore-test-foo {"id":"foo","body":"bar"} applike-gosoline-kvstore-kvstore-test-fuu {"id":"fuu","body":"baz"}]`
 		possibleInput2 := `[applike-gosoline-kvstore-kvstore-test-fuu {"id":"fuu","body":"baz"} applike-gosoline-kvstore-kvstore-test-foo {"id":"foo","body":"bar"}]`
 
@@ -137,7 +137,7 @@ func TestRedisKvStore_PutBatchSkipExpire(t *testing.T) {
 	})).Return(nil)
 	client.On("Pipeline").Return(pipe)
 	pipe.On("TxPipeline").Return(pipe)
-	pipe.On("Exec", mock.AnythingOfType("context.backgroundCtx")).Return(nil, nil)
+	pipe.On("Exec", mock.AnythingOfType("*context.emptyCtx")).Return(nil, nil)
 
 	items := map[string]Item{
 		"foo": {
@@ -158,7 +158,7 @@ func TestRedisKvStore_PutBatchSkipExpire(t *testing.T) {
 
 func TestRedisKvStore_EstimateSize(t *testing.T) {
 	store, client := buildTestableRedisStore[Item]()
-	client.On("DBSize", mock.AnythingOfType("context.backgroundCtx")).Return(int64(42), nil)
+	client.On("DBSize", mock.AnythingOfType("*context.emptyCtx")).Return(int64(42), nil)
 
 	size := store.(kvstore.SizedStore[Item]).EstimateSize()
 
@@ -168,7 +168,7 @@ func TestRedisKvStore_EstimateSize(t *testing.T) {
 
 func TestRedisKvStore_Delete(t *testing.T) {
 	store, client := buildTestableRedisStore[Item]()
-	client.On("Del", mock.AnythingOfType("context.backgroundCtx"), "applike-gosoline-kvstore-kvstore-test-foo").Return(int64(1), nil)
+	client.On("Del", mock.AnythingOfType("*context.emptyCtx"), "applike-gosoline-kvstore-kvstore-test-foo").Return(int64(1), nil)
 
 	err := store.Delete(context.Background(), "foo")
 
@@ -178,7 +178,7 @@ func TestRedisKvStore_Delete(t *testing.T) {
 
 func TestRedisKvStore_DeleteBatch(t *testing.T) {
 	store, client := buildTestableRedisStore[Item]()
-	client.On("Del", mock.AnythingOfType("context.backgroundCtx"), "applike-gosoline-kvstore-kvstore-test-foo", "applike-gosoline-kvstore-kvstore-test-fuu").Return(int64(2), nil)
+	client.On("Del", mock.AnythingOfType("*context.emptyCtx"), "applike-gosoline-kvstore-kvstore-test-foo", "applike-gosoline-kvstore-kvstore-test-fuu").Return(int64(2), nil)
 
 	items := []string{"foo", "fuu"}
 

--- a/pkg/lambda/lambda.go
+++ b/pkg/lambda/lambda.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	awsLambda "github.com/aws/aws-lambda-go/lambda"
+
 	"github.com/justtrackio/gosoline/pkg/appctx"
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/clock"
@@ -17,7 +18,7 @@ type HandlerFactory func(ctx context.Context, config cfg.Config, logger log.Logg
 func Start(handlerFactory HandlerFactory, configOptions ...cfg.Option) {
 	clock.WithUseUTC(true)
 
-	logHandler := log.NewHandlerIoWriter(log.LevelInfo, []string{}, log.FormatterConsole, "", os.Stdout)
+	logHandler := log.NewHandlerIoWriter(log.LevelInfo, []log.Channel{}, log.FormatterConsole, "", os.Stdout)
 	loggerOptions := []log.Option{
 		log.WithHandlers(logHandler),
 		log.WithContextFieldsResolver(log.ContextLoggerFieldsResolver),

--- a/pkg/lambda/lambda.go
+++ b/pkg/lambda/lambda.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	awsLambda "github.com/aws/aws-lambda-go/lambda"
-
 	"github.com/justtrackio/gosoline/pkg/appctx"
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/clock"

--- a/pkg/log/builtin.go
+++ b/pkg/log/builtin.go
@@ -13,5 +13,5 @@ func NewCliLogger() Logger {
 }
 
 func NewCliHandler() Handler {
-	return NewHandlerIoWriter(LevelInfo, []string{}, FormatterConsole, "15:04:05.000", os.Stdout)
+	return NewHandlerIoWriter(LevelInfo, []Channel{}, FormatterConsole, "15:04:05.000", os.Stdout)
 }

--- a/pkg/log/formatter.go
+++ b/pkg/log/formatter.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+
 	"github.com/justtrackio/gosoline/pkg/encoding/json"
 )
 

--- a/pkg/log/formatter.go
+++ b/pkg/log/formatter.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-
 	"github.com/justtrackio/gosoline/pkg/encoding/json"
 )
 

--- a/pkg/log/handler.go
+++ b/pkg/log/handler.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Handler interface {
-	Channels() []string
+	Channels() []Channel
 	Level() int
 	Log(timestamp time.Time, level int, msg string, args []interface{}, err error, data Data) error
 }

--- a/pkg/log/handler_iowriter.go
+++ b/pkg/log/handler_iowriter.go
@@ -13,11 +13,17 @@ func init() {
 }
 
 type HandlerIoWriterSettings struct {
-	Level           string   `cfg:"level" default:"info"`
-	Channels        []string `cfg:"channels"`
-	Formatter       string   `cfg:"formatter" default:"console"`
-	TimestampFormat string   `cfg:"timestamp_format" default:"15:04:05.000"`
-	Writer          string   `cfg:"writer" default:"stdout"`
+	Level           string    `cfg:"level" default:"info"`
+	Channels        []Channel `cfg:"channels"`
+	Formatter       string    `cfg:"formatter" default:"console"`
+	TimestampFormat string    `cfg:"timestamp_format" default:"15:04:05.000"`
+	Writer          string    `cfg:"writer" default:"stdout"`
+}
+
+type Channel struct {
+	Name     string `cfg:"name"`
+	Level    string `cfg:"level" default:"info"`
+	Disabled bool   `cfg:"disabled" default:"false"`
 }
 
 func handlerIoWriterFactory(config cfg.Config, name string) (Handler, error) {
@@ -48,13 +54,13 @@ func handlerIoWriterFactory(config cfg.Config, name string) (Handler, error) {
 
 type handlerIoWriter struct {
 	level           int
-	channels        []string
+	channels        []Channel
 	formatter       Formatter
 	timestampFormat string
 	writer          io.Writer
 }
 
-func NewHandlerIoWriter(level string, channels []string, formatter Formatter, timestampFormat string, writer io.Writer) *handlerIoWriter {
+func NewHandlerIoWriter(level string, channels []Channel, formatter Formatter, timestampFormat string, writer io.Writer) *handlerIoWriter {
 	return &handlerIoWriter{
 		level:           LevelPriority(level),
 		channels:        channels,
@@ -64,7 +70,7 @@ func NewHandlerIoWriter(level string, channels []string, formatter Formatter, ti
 	}
 }
 
-func (h *handlerIoWriter) Channels() []string {
+func (h *handlerIoWriter) Channels() []Channel {
 	return h.channels
 }
 

--- a/pkg/log/handler_sentry.go
+++ b/pkg/log/handler_sentry.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+
 	"github.com/justtrackio/gosoline/pkg/cfg"
 )
 
@@ -39,8 +40,8 @@ func (h *HandlerSentry) WithContext(name string, context map[string]interface{})
 	})
 }
 
-func (h *HandlerSentry) Channels() []string {
-	return []string{}
+func (h *HandlerSentry) Channels() []Channel {
+	return []Channel{}
 }
 
 func (h *HandlerSentry) Level() int {

--- a/pkg/log/handler_sentry.go
+++ b/pkg/log/handler_sentry.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
-
 	"github.com/justtrackio/gosoline/pkg/cfg"
 )
 

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/justtrackio/gosoline/pkg/clock"
 )
@@ -178,13 +177,7 @@ func (l *gosoLogger) log(level int, msg string, args []interface{}, loggedErr er
 	timestamp := l.clock.Now()
 
 	for _, handler := range l.handlers {
-		if handler.Level() > level {
-			continue
-		}
-
-		handlerChannels := handler.Channels()
-
-		if !l.shouldLogToChannels(l.data.Channel, handlerChannels) {
+		if !l.shouldLog(l.data.Channel, level, handler) {
 			continue
 		}
 
@@ -194,32 +187,13 @@ func (l *gosoLogger) log(level int, msg string, args []interface{}, loggedErr er
 	}
 }
 
-func (l *gosoLogger) shouldLogToChannels(current string, channels []string) bool {
-	if len(channels) == 0 {
-		return true
-	}
-
-	for _, channel := range channels {
-		if channel == "*" {
-			return true
-		}
-
-		if channel == current {
-			return true
-		}
-
-		if !strings.HasPrefix(channel, "!") {
-			continue
-		}
-
-		channel = strings.TrimPrefix(channel, "!")
-
-		if channel == current {
-			return false
+func (l *gosoLogger) shouldLog(current string, level int, h Handler) bool {
+	for _, channel := range h.Channels() {
+		if current == channel.Name {
+			return (levelPriorities[channel.Level] <= level) && !channel.Disabled
 		}
 	}
-
-	return false
+	return h.Level() <= level
 }
 
 func (l *gosoLogger) err(err error) {

--- a/pkg/log/logger_context_enforce_test.go
+++ b/pkg/log/logger_context_enforce_test.go
@@ -5,9 +5,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/justtrackio/gosoline/pkg/clock"
 	"github.com/justtrackio/gosoline/pkg/log"
-	"github.com/stretchr/testify/suite"
 )
 
 type ContextEnforcingLoggerTestSuite struct {
@@ -23,7 +24,7 @@ func (s *ContextEnforcingLoggerTestSuite) SetupTest() {
 	s.clock = clock.NewFakeClock()
 	s.output = &bytes.Buffer{}
 	s.base = log.NewLoggerWithInterfaces(s.clock, []log.Handler{
-		log.NewHandlerIoWriter(log.LevelInfo, []string{}, log.FormatterConsole, "15:04:05.000", s.output),
+		log.NewHandlerIoWriter(log.LevelInfo, []log.Channel{}, log.FormatterConsole, "15:04:05.000", s.output),
 	})
 
 	s.logger = log.NewContextEnforcingLoggerWithInterfaces(s.base, log.GetMockedStackTrace, s.base)
@@ -45,8 +46,8 @@ func (s *ContextEnforcingLoggerTestSuite) TestInfoWithoutContext() {
 }
 
 func (s *ContextEnforcingLoggerTestSuite) TestInfoWithoutContextWithChannel() {
-	s.logger.WithChannel("channel").Info("this is a info message")
-	s.Equal("00:00:00.000 context_missing warn    you should add the context to your logger: mocked trace\n00:00:00.000 channel info    this is a info message\n", s.output.String())
+	s.logger.WithChannel("Channel").Info("this is a info message")
+	s.Equal("00:00:00.000 context_missing warn    you should add the context to your logger: mocked trace\n00:00:00.000 Channel info    this is a info message\n", s.output.String())
 }
 
 func (s *ContextEnforcingLoggerTestSuite) TestInfoWithoutContextWithFields() {

--- a/pkg/log/logger_context_enforce_test.go
+++ b/pkg/log/logger_context_enforce_test.go
@@ -5,10 +5,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/justtrackio/gosoline/pkg/clock"
 	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/stretchr/testify/suite"
 )
 
 type ContextEnforcingLoggerTestSuite struct {

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -7,14 +7,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/justtrackio/gosoline/pkg/clock"
 	"github.com/justtrackio/gosoline/pkg/log"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestLoggerIoWriter(t *testing.T) {
 	buf := &bytes.Buffer{}
-	handler := log.NewHandlerIoWriter(log.LevelInfo, []string{"main"}, log.FormatterJson, time.RFC3339, buf)
+	handler := log.NewHandlerIoWriter(log.LevelInfo, []log.Channel{
+		{"main", "info", false},
+		{"error_channel", "error", false},
+		{"forbidden", "", true},
+	}, log.FormatterJson, time.RFC3339, buf)
 	cl := clock.NewFakeClock()
 
 	logger := log.NewLoggerWithInterfaces(cl, []log.Handler{handler})
@@ -24,7 +29,9 @@ func TestLoggerIoWriter(t *testing.T) {
 	cl.Advance(time.Minute)
 	logger.Info("bar")
 	logger.Debug("some debug")
-	logger.WithChannel("other channel").Info("something in another channel")
+	logger.WithChannel("forbidden").Info("something in forbidden channel")
+	logger.WithChannel("error_channel").Warn("not logged")
+	logger.WithChannel("error_channel").Error("error logged")
 
 	cl.Advance(time.Minute)
 	logger.Info("foobaz")
@@ -34,12 +41,13 @@ func TestLoggerIoWriter(t *testing.T) {
 	logger.Error("something went wrong: %w", err)
 
 	lines := getLogLines(buf)
-	assert.Len(t, lines, 4)
+	assert.Len(t, lines, 5)
 
 	assert.JSONEq(t, `{"channel":"main","context":{},"fields":{},"level":2,"level_name":"info","message":"foo","timestamp":"1984-04-04T00:00:00Z"}`, lines[0])
 	assert.JSONEq(t, `{"channel":"main","context":{},"fields":{},"level":2,"level_name":"info","message":"bar","timestamp":"1984-04-04T00:01:00Z"}`, lines[1])
-	assert.JSONEq(t, `{"channel":"main","context":{},"fields":{},"level":2,"level_name":"info","message":"foobaz","timestamp":"1984-04-04T00:02:00Z"}`, lines[2])
-	assert.JSONEq(t, `{"channel":"main","context":{},"err":"something went wrong: random error","fields":{},"level":4,"level_name":"error","message":"something went wrong: random error","timestamp":"1984-04-04T00:03:00Z"}`, lines[3])
+	assert.JSONEq(t, `{"channel":"error_channel","context":{},"err":"error logged","fields":{},"level":4,"level_name":"error","message":"error logged","timestamp":"1984-04-04T00:01:00Z"}`, lines[2])
+	assert.JSONEq(t, `{"channel":"main","context":{},"fields":{},"level":2,"level_name":"info","message":"foobaz","timestamp":"1984-04-04T00:02:00Z"}`, lines[3])
+	assert.JSONEq(t, `{"channel":"main","context":{},"err":"something went wrong: random error","fields":{},"level":4,"level_name":"error","message":"something went wrong: random error","timestamp":"1984-04-04T00:03:00Z"}`, lines[4])
 }
 
 func getLogLines(buf *bytes.Buffer) []string {

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/justtrackio/gosoline/pkg/clock"
 	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLoggerIoWriter(t *testing.T) {

--- a/pkg/log/mocks/factory.go
+++ b/pkg/log/mocks/factory.go
@@ -3,14 +3,15 @@ package mocks
 import (
 	"fmt"
 
-	"github.com/justtrackio/gosoline/pkg/log"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/justtrackio/gosoline/pkg/log"
 )
 
 func NewLoggerMock() *Logger {
 	logger := new(Logger)
 
-	logger.On("WithChannel", mock.AnythingOfType("string")).Return(logger).Maybe()
+	logger.On("WithChannel", mock.Anything).Return(logger).Maybe()
 	logger.On("WithContext", mock.Anything).Return(logger).Maybe()
 	logger.On("WithFields", mock.Anything).Return(logger).Maybe()
 

--- a/pkg/log/mocks/factory.go
+++ b/pkg/log/mocks/factory.go
@@ -3,9 +3,8 @@ package mocks
 import (
 	"fmt"
 
-	"github.com/stretchr/testify/mock"
-
 	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/stretchr/testify/mock"
 )
 
 func NewLoggerMock() *Logger {

--- a/pkg/metric/logger_handler.go
+++ b/pkg/metric/logger_handler.go
@@ -28,8 +28,8 @@ type LoggerHandler struct {
 	writer Writer
 }
 
-func (h LoggerHandler) Channels() []string {
-	return []string{}
+func (h LoggerHandler) Channels() []log.Channel {
+	return []log.Channel{}
 }
 
 func (h LoggerHandler) Level() int {

--- a/pkg/stream/input_sqs_test.go
+++ b/pkg/stream/input_sqs_test.go
@@ -24,7 +24,7 @@ func TestSqsInput_Run(t *testing.T) {
 	msg := &stream.Message{}
 
 	queue := new(sqsMocks.Queue)
-	queue.On("Receive", mock.AnythingOfType("context.backgroundCtx"), int32(1), int32(3)).Return(func(_ context.Context, mrc int32, wt int32) []types.Message {
+	queue.On("Receive", mock.AnythingOfType("*context.emptyCtx"), int32(1), int32(3)).Return(func(_ context.Context, mrc int32, wt int32) []types.Message {
 		newCount := atomic.AddInt32(&count, 1)
 
 		if newCount > mrc {

--- a/pkg/stream/output_redis_list_test.go
+++ b/pkg/stream/output_redis_list_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestRedisListOutput_WriteOne(t *testing.T) {
 	output, redisMock := setup(1)
-	redisMock.On("RPush", mock.AnythingOfType("context.backgroundCtx"), "mcoins-test-analytics-app-my-list", mock.AnythingOfType("[]uint8")).Return(int64(1), nil).Once()
+	redisMock.On("RPush", mock.AnythingOfType("*context.emptyCtx"), "mcoins-test-analytics-app-my-list", mock.AnythingOfType("[]uint8")).Return(int64(1), nil).Once()
 
 	record := stream.NewMessage("bla")
 	err := output.WriteOne(context.Background(), record)
@@ -26,7 +26,7 @@ func TestRedisListOutput_WriteOne(t *testing.T) {
 
 func TestRedisListOutput_Write(t *testing.T) {
 	output, redisMock := setup(2)
-	redisMock.On("RPush", mock.AnythingOfType("context.backgroundCtx"), "mcoins-test-analytics-app-my-list", mock.AnythingOfType("[]uint8"), mock.AnythingOfType("[]uint8")).Return(int64(2), nil).Once()
+	redisMock.On("RPush", mock.AnythingOfType("*context.emptyCtx"), "mcoins-test-analytics-app-my-list", mock.AnythingOfType("[]uint8"), mock.AnythingOfType("[]uint8")).Return(int64(2), nil).Once()
 
 	batch := []stream.WritableMessage{
 		stream.NewMessage("foo"),
@@ -40,7 +40,7 @@ func TestRedisListOutput_Write(t *testing.T) {
 
 func TestRedisListOutput_Write_Chunked(t *testing.T) {
 	output, redisMock := setup(1)
-	redisMock.On("RPush", mock.AnythingOfType("context.backgroundCtx"), "mcoins-test-analytics-app-my-list", mock.AnythingOfType("[]uint8")).Return(int64(1), nil).Times(2)
+	redisMock.On("RPush", mock.AnythingOfType("*context.emptyCtx"), "mcoins-test-analytics-app-my-list", mock.AnythingOfType("[]uint8")).Return(int64(1), nil).Times(2)
 
 	batch := []stream.WritableMessage{
 		stream.NewMessage("foo"),

--- a/pkg/test/env/logging.go
+++ b/pkg/test/env/logging.go
@@ -24,7 +24,7 @@ func NewConsoleLogger(options ...LoggerOption) (log.GosoLogger, error) {
 	}
 
 	cl := clock.NewRealClock()
-	handler := log.NewHandlerIoWriter(settings.Level, []string{}, log.FormatterConsole, "15:04:05.000", os.Stdout)
+	handler := log.NewHandlerIoWriter(settings.Level, []log.Channel{}, log.FormatterConsole, "15:04:05.000", os.Stdout)
 
 	return log.NewLoggerWithInterfaces(cl, []log.Handler{handler}), nil
 }

--- a/pkg/tracing/logging.go
+++ b/pkg/tracing/logging.go
@@ -31,8 +31,8 @@ func NewLoggerErrorHandler() *LoggerErrorHandler {
 	return &LoggerErrorHandler{}
 }
 
-func (h *LoggerErrorHandler) Channels() []string {
-	return []string{}
+func (h *LoggerErrorHandler) Channels() []log.Channel {
+	return []log.Channel{}
 }
 
 func (h *LoggerErrorHandler) Level() int {

--- a/test/apiserver/eof_bind_test.go
+++ b/test/apiserver/eof_bind_test.go
@@ -12,7 +12,6 @@ import (
 
 	httpHeaders "github.com/go-http-utils/headers"
 	"github.com/go-resty/resty/v2"
-
 	"github.com/justtrackio/gosoline/pkg/apiserver"
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/http"

--- a/test/apiserver/eof_bind_test.go
+++ b/test/apiserver/eof_bind_test.go
@@ -12,6 +12,7 @@ import (
 
 	httpHeaders "github.com/go-http-utils/headers"
 	"github.com/go-resty/resty/v2"
+
 	"github.com/justtrackio/gosoline/pkg/apiserver"
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/http"
@@ -47,7 +48,7 @@ type bindHandler struct {
 	suite.Suite
 }
 
-func (b bindHandler) Channels() []string {
+func (b bindHandler) Channels() []log.Channel {
 	return nil
 }
 


### PR DESCRIPTION
Commit `e1d72fb62092631738b376fea846c4d6f4caf3dc` adds log level filter per channel for iowriter log handler. 

```yaml
    handlers:
        main:
            type: iowriter
            channels:
              # Excludes logs from "metrics" channel altogether.
              - name: metrics
                disabled: false
              # Logs debug and above for "test" channel.
              - name: test
                level: debug
            formatter: console
            level: info
            timestamp_format: 15:04:05.000
            writer: stdout
```

Commit `c0b05bf2e44925182c85a60022e2c0f986cd25e4` fixes test failures, mostly due to package updates. Can be removed from this PR depending on the needs.